### PR TITLE
Fix Postgres placeholder handling in raw TypeORM queries

### DIFF
--- a/package/src/typeorm-adapter.ts
+++ b/package/src/typeorm-adapter.ts
@@ -1145,22 +1145,12 @@ export const typeormAdapter = (dataSource: DataSource, options?: TypeormAdapterO
         const queryRunner = dataSource.createQueryRunner();
         await queryRunner.connect();
         try {
-          const result = await (
-            queryRunner as typeof queryRunner & {
-              query(query: string, parameters?: unknown[], useStructuredResult?: boolean): Promise<{
-                affected?: number;
-                changes?: number;
-              }>;
-            }
-          ).query(
+          const result = await queryRunner.query(
             `UPDATE ${escapeId(dataSource, tableName)} SET ${setClauses.join(", ")}${whereSql}`,
             [...setValues, ...whereParams],
             true,
           );
-          if (typeof result?.affected === "number") {
-            return result.affected;
-          }
-          return typeof result?.changes === "number" ? result.changes : 0;
+          return getAffectedRowCount(result);
         } finally {
           await queryRunner.release();
         }
@@ -1173,25 +1163,24 @@ export const typeormAdapter = (dataSource: DataSource, options?: TypeormAdapterO
         const queryRunner = dataSource.createQueryRunner();
         await queryRunner.connect();
         try {
-          const result = await (
-            queryRunner as typeof queryRunner & {
-              query(query: string, parameters?: unknown[], useStructuredResult?: boolean): Promise<{
-                affected?: number;
-                changes?: number;
-              }>;
-            }
-          ).query(
+          const result = await queryRunner.query(
             `DELETE FROM ${escapeId(dataSource, tableName)}${sql}`,
             params,
             true,
           );
-          if (typeof result?.affected === "number") {
-            return result.affected;
-          }
-          return typeof result?.changes === "number" ? result.changes : 0;
+          return getAffectedRowCount(result);
         } finally {
           await queryRunner.release();
         }
+      }
+
+      function getAffectedRowCount(result: { affected?: number } & Record<string, unknown>): number {
+        if (typeof result.affected === "number") {
+          return result.affected;
+        }
+
+        const changes = result["changes"];
+        return typeof changes === "number" ? changes : 0;
       }
 
       return {

--- a/package/src/typeorm-adapter.ts
+++ b/package/src/typeorm-adapter.ts
@@ -52,6 +52,30 @@ function escapeId(dataSource: DataSource, name: string): string {
   return dataSource.driver.escape(name);
 }
 
+function createParameterToken(dataSource: DataSource, index: number): string {
+  return dataSource.driver.createParameter(`orm_param_${index}`, index);
+}
+
+function pushParameter(
+  dataSource: DataSource,
+  params: unknown[],
+  value: unknown,
+  startIndex = 0,
+): string {
+  params.push(value);
+  return createParameterToken(dataSource, startIndex + params.length - 1);
+}
+
+function normalizeQueryValue(value: unknown): unknown {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (typeof value === "object" && value !== null) {
+    return JSON.stringify(value);
+  }
+  return value;
+}
+
 async function ensureTableExists(
   dataSource: DataSource,
   tableName: string,
@@ -74,7 +98,7 @@ async function ensureTableExists(
               : typeof value === "number"
                 ? "integer"
                 : value instanceof Date
-                  ? "datetime"
+                  ? getDateColumnType(dataSource)
                   : "text";
           return `${escaped} ${type}`;
         })
@@ -94,7 +118,7 @@ async function ensureTableExists(
                 : typeof value === "number"
                   ? "integer"
                   : value instanceof Date
-                    ? "datetime"
+                    ? getDateColumnType(dataSource)
                     : "text";
             await queryRunner.query(
               `ALTER TABLE ${escapeId(dataSource, tableName)} ADD COLUMN ${escapeId(dataSource, key)} ${type}`,
@@ -645,6 +669,7 @@ export const typeormAdapter = (dataSource: DataSource, options?: TypeormAdapterO
           | "deleteMany"
           | "count",
         where?: Where[],
+        startIndex = 0,
       ) {
         const cleaned = where?.length ? transformWhereClause({ model, where, action }) : [];
 
@@ -666,8 +691,7 @@ export const typeormAdapter = (dataSource: DataSource, options?: TypeormAdapterO
           const col = escapeId(dataSource, mappedFieldName);
 
           const push = (value: unknown) => {
-            params.push(value);
-            return "?";
+            return pushParameter(dataSource, params, value, startIndex);
           };
 
           switch (w.operator ?? "eq") {
@@ -828,16 +852,10 @@ export const typeormAdapter = (dataSource: DataSource, options?: TypeormAdapterO
         }
         const entries = Object.entries(insertData).filter(([, value]) => value !== undefined);
         const columns = entries.map(([key]) => escapeId(dataSource, key)).join(", ");
-        const placeholders = entries.map(() => "?").join(", ");
-        const values = entries.map(([, value]) => {
-          if (value instanceof Date) {
-            return value.toISOString();
-          }
-          if (typeof value === "object" && value !== null) {
-            return JSON.stringify(value);
-          }
-          return value;
-        });
+        const placeholders = entries
+          .map((_, index) => createParameterToken(dataSource, index))
+          .join(", ");
+        const values = entries.map(([, value]) => normalizeQueryValue(value));
 
         try {
           const isSqlite =
@@ -855,7 +873,7 @@ export const typeormAdapter = (dataSource: DataSource, options?: TypeormAdapterO
           }
 
           const rows = await queryRunner.query(
-            `SELECT * FROM ${escapeId(dataSource, tableName)} WHERE ${escapeId(dataSource, "id")} = ?`,
+            `SELECT * FROM ${escapeId(dataSource, tableName)} WHERE ${escapeId(dataSource, "id")} = ${createParameterToken(dataSource, 0)}`,
             [mappedData.id],
           );
 
@@ -1020,26 +1038,22 @@ export const typeormAdapter = (dataSource: DataSource, options?: TypeormAdapterO
           const setValues: unknown[] = [];
           for (const [key, value] of Object.entries(transformed)) {
             if (value !== undefined) {
-              setClauses.push(`${escapeId(dataSource, key)} = ?`);
-              if (value instanceof Date) {
-                setValues.push(value.toISOString());
-              } else if (typeof value === "object" && value !== null) {
-                setValues.push(JSON.stringify(value));
-              } else {
-                setValues.push(value);
-              }
+              setClauses.push(
+                `${escapeId(dataSource, key)} = ${createParameterToken(dataSource, setValues.length)}`,
+              );
+              setValues.push(normalizeQueryValue(value));
             }
           }
 
           if (setClauses.length > 0) {
             await queryRunner.query(
-              `UPDATE ${escapeId(dataSource, tableName)} SET ${setClauses.join(", ")} WHERE ${escapeId(dataSource, "id")} = ?`,
+              `UPDATE ${escapeId(dataSource, tableName)} SET ${setClauses.join(", ")} WHERE ${escapeId(dataSource, "id")} = ${createParameterToken(dataSource, setValues.length)}`,
               [...setValues, existing[0].id],
             );
           }
 
           const result = await queryRunner.query(
-            `SELECT * FROM ${escapeId(dataSource, tableName)} WHERE ${escapeId(dataSource, "id")} = ?`,
+            `SELECT * FROM ${escapeId(dataSource, tableName)} WHERE ${escapeId(dataSource, "id")} = ${createParameterToken(dataSource, 0)}`,
             [existing[0].id],
           );
 
@@ -1106,20 +1120,14 @@ export const typeormAdapter = (dataSource: DataSource, options?: TypeormAdapterO
         const tableName = getModelName(model);
         const transformed = await transformInput(update, defaultModelName, "update");
 
-        const { sql: whereSql, params: whereParams } = buildWhereSql(model, "updateMany", where);
-
         const setClauses: string[] = [];
         const setValues: unknown[] = [];
         for (const [key, value] of Object.entries(transformed)) {
           if (value !== undefined) {
-            setClauses.push(`${escapeId(dataSource, key)} = ?`);
-            if (value instanceof Date) {
-              setValues.push(value.toISOString());
-            } else if (typeof value === "object" && value !== null) {
-              setValues.push(JSON.stringify(value));
-            } else {
-              setValues.push(value);
-            }
+            setClauses.push(
+              `${escapeId(dataSource, key)} = ${createParameterToken(dataSource, setValues.length)}`,
+            );
+            setValues.push(normalizeQueryValue(value));
           }
         }
 
@@ -1127,13 +1135,31 @@ export const typeormAdapter = (dataSource: DataSource, options?: TypeormAdapterO
           return 0;
         }
 
+        const { sql: whereSql, params: whereParams } = buildWhereSql(
+          model,
+          "updateMany",
+          where,
+          setValues.length,
+        );
+
         const queryRunner = dataSource.createQueryRunner();
         await queryRunner.connect();
         try {
-          const result = await queryRunner.query(
+          const result = await (
+            queryRunner as typeof queryRunner & {
+              query(query: string, parameters?: unknown[], useStructuredResult?: boolean): Promise<{
+                affected?: number;
+                changes?: number;
+              }>;
+            }
+          ).query(
             `UPDATE ${escapeId(dataSource, tableName)} SET ${setClauses.join(", ")}${whereSql}`,
             [...setValues, ...whereParams],
+            true,
           );
+          if (typeof result?.affected === "number") {
+            return result.affected;
+          }
           return typeof result?.changes === "number" ? result.changes : 0;
         } finally {
           await queryRunner.release();
@@ -1147,10 +1173,21 @@ export const typeormAdapter = (dataSource: DataSource, options?: TypeormAdapterO
         const queryRunner = dataSource.createQueryRunner();
         await queryRunner.connect();
         try {
-          const result = await queryRunner.query(
+          const result = await (
+            queryRunner as typeof queryRunner & {
+              query(query: string, parameters?: unknown[], useStructuredResult?: boolean): Promise<{
+                affected?: number;
+                changes?: number;
+              }>;
+            }
+          ).query(
             `DELETE FROM ${escapeId(dataSource, tableName)}${sql}`,
             params,
+            true,
           );
+          if (typeof result?.affected === "number") {
+            return result.affected;
+          }
           return typeof result?.changes === "number" ? result.changes : 0;
         } finally {
           await queryRunner.release();


### PR DESCRIPTION
## Summary
- replace hard-coded `?` placeholders with TypeORM driver-specific parameter tokens
- use the existing driver date type helper in the fallback table/column creation path
- return affected row counts for `updateMany`/`deleteMany` on drivers that expose `affected` instead of SQLite-style `changes`

## Why
The adapter README says it supports PostgreSQL, but the raw query paths were building SQL with `?` placeholders. That works on SQLite/MySQL, but Postgres expects `$1`, `$2`, etc.

In practice this breaks auth flows like sign up / sign in on Postgres because queries end up looking like:

```sql
SELECT * FROM "user" WHERE "email" = ? LIMIT 1
```

Postgres rejects that statement and surfaces the parse error near `LIMIT`.

## Details
- `buildWhereSql()` now uses `dataSource.driver.createParameter(...)`
- raw insert/update/fetch-by-id queries now use driver-specific placeholders too
- the fallback schema code now uses `getDateColumnType(dataSource)` instead of hard-coded `datetime`, which is not valid on Postgres
- `updateMany` and `deleteMany` now support drivers that report row counts through `affected`

## Validation
- `bun run build`
- `bun run test`

The existing test suite still passes after the change:
- `vitest`: `205 passed | 7 skipped`
- `bun test sqlite.test.ts`: `29 passed`

## Notes
I did not add a new Postgres integration test here because the current test setup is SQLite-only, but this change was verified against the adapter's current suite and fixes the Postgres-specific placeholder generation bug directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parameter handling for database queries to ensure correct placeholder sequencing across statements.
  * Normalized query values (e.g., dates and objects) before sending to the database to avoid type inconsistencies.
  * Resolved date column type detection for table/column creation to match the target database.
  * Fixed batch operation reporting so affected-row counts are accurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->